### PR TITLE
fix bootstrap can't modify gid issue

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -146,7 +146,7 @@ echo "${TZ}" > /etc/timezone
 echo "Checking if UID: ${UID} matches user"
 usermod -u ${UID} alpha
 echo "Checking if GID: ${GID} matches user"
-usermod -g ${GID} alpha
+groupmod -g ${GID} alpha
 echo "Setting umask to ${UMASK}"
 umask ${UMASK}
 


### PR DESCRIPTION
Fix can't modify group issue

docker run --rm -it -e PUID=1001 -e PGID=1001 ... vergilgao/avdc:6.0.2
Setup Timezone to Asia/Shanghai
Checking if UID: 1001 matches user
Checking if GID: 1001 matches user
usermod: group '1001' does not exist
Setting umask to 000
Checking if config file exist
Starting...
